### PR TITLE
fix: allow first-party morpher.com subdomains as wallet parent origin

### DIFF
--- a/vue/src/store/index.ts
+++ b/vue/src/store/index.ts
@@ -1221,7 +1221,10 @@ if (isIframe()) {
 	store.state.connection = connectToParent({
 		parentOrigin:
 			process.env.NODE_ENV === 'production'
-				? /^https:\/\/[w]{0,3}\.?morpher\.com\/?.*$/
+				// Allow any first-party morpher.com origin (e.g. www.morpher.com,
+				// close.morpher.com). Anchored to the end so look-alike domains such
+				// as morpher.com.evil.com no longer match (the old `\/?.*$` did).
+				? /^https:\/\/([a-z0-9-]+\.)?morpher\.com$/
 				: /.*/gm,
 				
 		// Methods child is exposing to parent


### PR DESCRIPTION
## What
Broaden the production `parentOrigin` allowlist for the embedded wallet iframe from only `morpher.com`/`www.morpher.com` to **any first-party `*.morpher.com` subdomain**, and anchor the regex to the end.

```diff
- /^https:\/\/[w]{0,3}\.?morpher\.com\/?.*$/
+ /^https:\/\/([a-z0-9-]+\.)?morpher\.com$/
```

## Why
The Morpher wind-down "close your positions" dapp (`Morpher-io/morpher-close`) will be hosted at **`close.morpher.com`** and must embed this wallet. The old regex only matched `morpher.com`/`www`, so the wallet iframe rejected the `close.morpher.com` parent origin via Penpal.

## Security
The previous trailing `\/?.*$` made look-alike domains like `https://morpher.com.evil.com` match. Anchoring with `$` closes that. Verified:

| origin | matches |
|---|---|
| https://morpher.com | ✅ |
| https://www.morpher.com | ✅ |
| https://close.morpher.com | ✅ |
| https://morpher.com.evil.com | ❌ (was ✅) |
| https://evil-morpher.com | ❌ |

Non-production behaviour (`/.*/gm`) is unchanged.